### PR TITLE
Update influxdb.py

### DIFF
--- a/dsc_datatool/output/influxdb.py
+++ b/dsc_datatool/output/influxdb.py
@@ -67,9 +67,9 @@ class InfluxDB(Output):
         append = opts.get('append', False)
         if file:
             if append:
-                self.fh = open(file, 'a')
+                self.fh = open(file, 'a', encoding="utf-8")
             else:
-                self.fh = open(file, 'w')
+                self.fh = open(file, 'w', encoding="utf-8")
             atexit.register(self.close)
         else:
             self.fh = sys.stdout


### PR DESCRIPTION
fix: 'ascii' codec can't encode character '\xe9' in position x: ordinal not in range(128) errors